### PR TITLE
Bump to v2.4.6

### DIFF
--- a/manifest
+++ b/manifest
@@ -1,6 +1,6 @@
 : 1
 name: doctest
-version: 2.4.0
+version: 2.4.6
 summary: The fastest feature-rich C++11/14/17/20 single-header testing framework for unit tests and TDD
 license: MIT
 description-file: upstream/README.md


### PR DESCRIPTION
These changes makes this package ready for `doctest` v2.4.6

CI results: https://ci.stage.build2.org/@73ccd582-91a6-4528-8dd6-1e29fa465c3a?builds&p=1

Once merged, you will need to `bdep release --tag --push` and then `bdep publish`.
If you don't have the time I can do it for you.
